### PR TITLE
Fix Framed Blocks conflict when other mods are present

### DIFF
--- a/src/main/java/nuclearscience/common/block/BlockElectromagneticBooster.java
+++ b/src/main/java/nuclearscience/common/block/BlockElectromagneticBooster.java
@@ -8,7 +8,6 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,13 +18,14 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import nuclearscience.common.block.states.NuclearScienceBlockStates;
 import nuclearscience.common.block.states.facing.FacingDirection;
 import voltaic.common.block.states.VoltaicBlockStates;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.tile.IWrenchable;
 
 public class BlockElectromagneticBooster extends Block implements IWrenchable {
 
 
 	public BlockElectromagneticBooster() {
-		super(Blocks.GLASS.properties().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((x, y, z) -> false));
+		super(VoltaicMaterials.glass().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((x, y, z) -> false));
 		registerDefaultState(stateDefinition.any().setValue(VoltaicBlockStates.FACING, Direction.NORTH).setValue(NuclearScienceBlockStates.FACINGDIRECTION, FacingDirection.NONE));
 	}
 

--- a/src/main/java/nuclearscience/common/block/BlockElectromagneticDiode.java
+++ b/src/main/java/nuclearscience/common/block/BlockElectromagneticDiode.java
@@ -10,7 +10,6 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,6 +18,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import voltaic.common.block.states.VoltaicBlockStates;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.tile.IWrenchable;
 
 public class BlockElectromagneticDiode extends Block implements IWrenchable {
@@ -26,7 +26,7 @@ public class BlockElectromagneticDiode extends Block implements IWrenchable {
     private static final VoxelShape SHAPE = Shapes.box(0, 0, 0, 1.0, 2.0 / 16.0, 1.0);
 
     public BlockElectromagneticDiode() {
-        super(Blocks.IRON_BLOCK.properties().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((p1, p2, p3) -> false));
+        super(VoltaicMaterials.metal().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((p1, p2, p3) -> false));
         registerDefaultState(stateDefinition.any().setValue(VoltaicBlockStates.FACING, Direction.NORTH));
     }
 

--- a/src/main/java/nuclearscience/common/block/BlockElectromagneticSwitch.java
+++ b/src/main/java/nuclearscience/common/block/BlockElectromagneticSwitch.java
@@ -6,11 +6,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockElectromagneticSwitch extends Block {
 	private static final VoxelShape SHAPE = Shapes.box(0, 0, 0, 1.0, 2.0 / 16.0, 1.0);
@@ -21,7 +21,7 @@ public class BlockElectromagneticSwitch extends Block {
 	}
 
 	public BlockElectromagneticSwitch() {
-		super(Blocks.IRON_BLOCK.properties().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((p1, p2, p3) -> false));
+		super(VoltaicMaterials.metal().strength(3.5f, 20).requiresCorrectToolForDrops().noOcclusion().isRedstoneConductor((p1, p2, p3) -> false));
 	}
 
 	@Override

--- a/src/main/java/nuclearscience/common/block/BlockMeltedReactor.java
+++ b/src/main/java/nuclearscience/common/block/BlockMeltedReactor.java
@@ -4,17 +4,17 @@ import com.mojang.serialization.MapCodec;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.BaseEntityBlock;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import nuclearscience.common.tile.reactor.fission.TileMeltedReactor;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlockWaterloggable;
 
 public class BlockMeltedReactor extends GenericEntityBlockWaterloggable {
 
 	public BlockMeltedReactor() {
-		super(Blocks.IRON_BLOCK.properties().strength(250.0f, 999.0f).sound(SoundType.METAL).requiresCorrectToolForDrops().noOcclusion());
+		super(VoltaicMaterials.metal().strength(250.0f, 999.0f).sound(SoundType.METAL).requiresCorrectToolForDrops().noOcclusion());
 	}
 
 	@Override

--- a/src/main/java/nuclearscience/common/block/BlockPlasma.java
+++ b/src/main/java/nuclearscience/common/block/BlockPlasma.java
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseEntityBlock;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -17,12 +16,13 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import nuclearscience.common.tile.reactor.fusion.TilePlasma;
 import nuclearscience.registers.NuclearScienceDamageTypes;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlock;
 
 public class BlockPlasma extends GenericEntityBlock {
 
     public BlockPlasma() {
-	super(Blocks.NETHER_PORTAL.properties().noCollission().randomTicks().strength(-1.0F).sound(SoundType.GLASS));
+	super(VoltaicMaterials.portal().noCollission().randomTicks().strength(-1.0F).sound(SoundType.GLASS));
     }
 
     @Override

--- a/src/main/java/nuclearscience/common/block/BlockRadioactiveAir.java
+++ b/src/main/java/nuclearscience/common/block/BlockRadioactiveAir.java
@@ -11,12 +11,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import voltaic.api.radiation.RadiationSystem;
 import voltaic.api.radiation.util.IRadiationRecipient;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.registers.VoltaicCapabilities;
 
 public class BlockRadioactiveAir extends AirBlock {
 
     public BlockRadioactiveAir() {
-        super(Blocks.AIR.properties().noCollission().air().randomTicks());
+        super(VoltaicMaterials.air().noCollission().air().randomTicks());
     }
 
     @Override

--- a/src/main/java/nuclearscience/common/block/BlockTurbine.java
+++ b/src/main/java/nuclearscience/common/block/BlockTurbine.java
@@ -9,7 +9,6 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -20,6 +19,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import nuclearscience.common.tile.TileTurbine;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlockWaterloggable;
 
 public class BlockTurbine extends GenericEntityBlockWaterloggable {
@@ -45,7 +45,7 @@ public class BlockTurbine extends GenericEntityBlockWaterloggable {
     public static final BooleanProperty RENDER = BooleanProperty.create("render");
 
     public BlockTurbine() {
-        super(Blocks.IRON_BLOCK.properties().strength(3.5F).sound(SoundType.METAL).requiresCorrectToolForDrops().noOcclusion());
+        super(VoltaicMaterials.metal().strength(3.5F).sound(SoundType.METAL).requiresCorrectToolForDrops().noOcclusion());
         registerDefaultState(stateDefinition.any().setValue(RENDER, true));
     }
 

--- a/src/main/java/nuclearscience/common/block/connect/BlockMoltenSaltPipe.java
+++ b/src/main/java/nuclearscience/common/block/connect/BlockMoltenSaltPipe.java
@@ -8,7 +8,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -18,6 +17,7 @@ import nuclearscience.common.tile.reactor.moltensalt.TileMSReactorCore;
 import nuclearscience.common.tile.reactor.moltensalt.TileMoltenSaltPipe;
 import voltaic.common.block.connect.AbstractRefreshingConnectBlock;
 import voltaic.common.block.connect.EnumConnectType;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockMoltenSaltPipe extends AbstractRefreshingConnectBlock<TileMoltenSaltPipe> {
 
@@ -26,7 +26,7 @@ public class BlockMoltenSaltPipe extends AbstractRefreshingConnectBlock<TileMolt
     public final SubtypeMoltenSaltPipe pipe;
 
     public BlockMoltenSaltPipe(SubtypeMoltenSaltPipe pipe) {
-        super(Blocks.IRON_BLOCK.properties().sound(SoundType.METAL).strength(0.15f).dynamicShape(), 3);
+        super(VoltaicMaterials.metal().sound(SoundType.METAL).strength(0.15f).dynamicShape(), 3);
         this.pipe = pipe;
         PIPESET.add(this);
     }

--- a/src/main/java/nuclearscience/common/block/connect/BlockReactorLogisticsCable.java
+++ b/src/main/java/nuclearscience/common/block/connect/BlockReactorLogisticsCable.java
@@ -10,7 +10,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,6 +18,7 @@ import nuclearscience.common.block.subtype.SubtypeReactorLogisticsCable;
 import nuclearscience.common.tile.reactor.logisticsnetwork.TileReactorLogisticsCable;
 import voltaic.common.block.connect.AbstractRefreshingConnectBlock;
 import voltaic.common.block.connect.EnumConnectType;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockReactorLogisticsCable extends AbstractRefreshingConnectBlock<TileReactorLogisticsCable> {
 
@@ -27,7 +27,7 @@ public class BlockReactorLogisticsCable extends AbstractRefreshingConnectBlock<T
     public final SubtypeReactorLogisticsCable cable;
 
     public BlockReactorLogisticsCable(SubtypeReactorLogisticsCable cable) {
-        super(Blocks.IRON_BLOCK.properties().sound(SoundType.METAL).strength(0.15f).dynamicShape(), 5);
+        super(VoltaicMaterials.metal().sound(SoundType.METAL).strength(0.15f).dynamicShape(), 5);
         this.cable = cable;
         PIPESET.add(this);
     }


### PR DESCRIPTION
When installed alongside Bad Packets, CraftedCore, and Create, any block that is set up in its registration using aFullCopy(Blocks.IRON_BLOCK) definition from any other mod is unable to be used as a texture for a Framed Block from the Framed Blocks mod if Voltaic or any of the other mods are installed. It also seems to affect glass and TNT.

I have fixed this by changing the super(Blocks.IRON_BLOCK) as well as the GLASS, TNT, and WHITE_WOOL entries to use the VoltaicMaterials.materialName() methods instead. This fixes the issue. It doesn't look like Modular Forcefields uses the super(Blocks.NAME) anywhere so I have not submitted a fix for it.